### PR TITLE
Fixes page issue

### DIFF
--- a/handletrack.go
+++ b/handletrack.go
@@ -72,10 +72,16 @@ func (ctx *Ctx) handleTrack() {
 		visit["ref"] = parsedUrl.Host
 	}
 
-	ref := ctx.r.Header.Get("Referer")
-	parsedUrl, err = url.Parse(ref)
-	if err == nil && parsedUrl.Path != "" {
-		visit["loc"] = parsedUrl.Path
+	page := ctx.r.FormValue("page")
+	if page != "" {
+		visit["loc"] = page
+	} else {
+		// Fallback to Referer header
+		ref := ctx.r.Header.Get("Referer")
+		parsedUrl, err = url.Parse(ref)
+		if err == nil && parsedUrl.Path != "" {
+			visit["loc"] = parsedUrl.Path
+		}
 	}
 
 	tags, _, err := language.ParseAcceptLanguage(ctx.r.Header.Get("Accept-Language"))

--- a/static/components/counter-trackingcode.js
+++ b/static/components/counter-trackingcode.js
@@ -2,7 +2,7 @@ customElements.define(
     tagName(),
     class extends HTMLElement {
         getTrackingCode(user, utcoffset) {
-            return `<script>if(!sessionStorage.getItem("_swa")&&document.referrer.indexOf(location.protocol+"//"+location.host)!== 0){fetch("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,user:${JSON.stringify(
+            return `<script>if(!sessionStorage.getItem("_swa")&&!document.referrer.startsWith(location.protocol+"//"+location.host)){navigator.sendBeacon("https://counter.dev/track?"+new URLSearchParams({referrer:document.referrer,screen:screen.width+"x"+screen.height,page:location.pathname,user:${JSON.stringify(
                 user
             )},utcoffset:${JSON.stringify(
                 utcoffset


### PR DESCRIPTION
Trying counter.dev out and so far it is awesome!

I noticed thought that my requests to nested routes where showing up as `"/"`. Looking at the source it seems that the page / `loc` is based of the `Referer` header value. However the [referer header documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) says it is not certain that the browser will include the path segment. I double checked the request using dev tools and it seems that was the issue in my case where on a nested route it was only sending the origin.

I have fixed this by explicitly sending `location.pathname` so it is certain that pathname will be sent. This value does not include fragment identifier or querystring. I have updated the snippet to include this as well as modifying the `handletrack.go` to read the page parameter (and falling back to `Referer` for older snippets that do not send this value). 

Two other changes to the snippet:
- Using `startsWith` over `indexOf(...) !== 0`
- Using [`navigator.sendBeacon`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon) over `fetch`. This request has lower precedence and is more efficient and is preferred for analytics

**I haven't tested these locally yet** but it should be okay. Let me know if there are any changes you want to this 👍 