### PR TITLE
Add t.co as social referrer

### DIFF
--- a/static/components/dashboard/counter/social.js
+++ b/static/components/dashboard/counter/social.js
@@ -108,6 +108,7 @@ customElements.define(
             // addedd manually.
             "indiehackers.com",
             "dev.to",
+            "t.co",
         ]);
     }
 );


### PR DESCRIPTION
Links posted in a tweet always use the t.co proxy before redirecting to the original website. This means that "t.co" is the referrer for twitter.com.