### PR TITLE
Allow adding country from proxy

### DIFF
--- a/backend/endpoints/track.go
+++ b/backend/endpoints/track.go
@@ -109,7 +109,11 @@ func init() {
 			visit["lang"] = lang
 		}
 
-		country := ctx.R.Header.Get("CF-IPCountry")
+		country := ctx.R.FormValue("country")
+		if country == "" {
+			country := ctx.R.Header.Get("CF-IPCountry")
+		}
+		
 		if country != "" && country != "XX" {
 			visit["country"] = strings.ToLower(country)
 		}


### PR DESCRIPTION
When tracking calls are proxied through a proxy before Cloudflare the visitor country is set to the proxy's location. Let's enable this overwrite so that we can have the proxy.