### PR TITLE
Group Gmail in traffic sources

### DIFF
--- a/static/components/dashboard/sources-countries.js
+++ b/static/components/dashboard/sources-countries.js
@@ -212,6 +212,14 @@ customElements.define(
                 link: "marketingplatform.google.com",
                 icon: "google.com",
             },
+            "Google Gmail": {
+                match: [
+                    "com.google.android.gm",
+                    "mail.google.com",
+                ],
+                link: "mail.google.com",
+                icon: "mail.google.com",
+            },
             Twitter: {
                 match: [
                     "t.co",


### PR DESCRIPTION
This proposes to mark Gmail specifically as "Google Gmail" in the traffic sources list, to avoid users not understanding what `com.google.android.gm` relates to, where a visitor comes from the Gmail Android app, and should also stop Gmail web from being categorised as Google search.