### PR TITLE
Update text style in option tag (select)

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -546,7 +546,7 @@ select {
   border: 1px solid #e0e0e0;
   border-radius: 3px;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.04);
-  font: 400 18px "Nunito Sans";
+  font: 400 18px "Nunito Sans", sans-serif;
   color: #121212;
   background: url(../img/arrow--blue.svg) right 12px center no-repeat #ffffff;
   cursor: pointer;


### PR DESCRIPTION
In the Firefox browser, the `<option>` tag does not inherit the text style of the parent `<select>` tag. Firefox allows only system fonts to be used in the `<option>` tag, but we can specify a sans-serif font family.

Screenshot
[https://drive.proton.me/urls/8H4K0NFE9W#3WcsbSvSpKzN](https://drive.proton.me/urls/8H4K0NFE9W#3WcsbSvSpKzN)