### PR TITLE
design: show-dates-in-recent-visits-on-mobile (fix #109)

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -483,10 +483,13 @@
   .graph,
   .metrics-headline,
   .sources-countries-data,
-  .visits-date,
+  /* .visits-date, */
   .headline-right img,
   .project img {
     display: none;
+  }
+  .visits-referrer {
+    width: 140px;
   }
   .metrics-one {
     margin: 8px 0 16px 0;
@@ -550,6 +553,11 @@
   }
   .metrics-three-data {
     margin: 0;
+  }
+  .metrics-three-data-content,
+  .metrics-three-data-headline {
+    padding-left: 16px;
+    padding-right: 16px;
   }
   .languages-screens-group {
     width: 100%;


### PR DESCRIPTION
Noticed the same issue as in #109.
I reduced the horizontal padding of the entire container from `24` to `16` otherwise the referrer is squished.
BEFORE:
![Screenshot 2024-04-29 at 8 02 52 PM](https://github.com/ihucos/counter.dev/assets/30526133/16ff45c2-6f60-470c-b1f1-84e453477c4b)

AFTER:
![Screenshot 2024-04-29 at 8 03 21 PM](https://github.com/ihucos/counter.dev/assets/30526133/191ef209-cbda-47db-80d5-5f5e2c00a1c5)
