### PR TITLE
Clear wording in "pay what you want" component

### DIFF
--- a/static/components/base/pwyw.js
+++ b/static/components/base/pwyw.js
@@ -13,8 +13,8 @@ customElements.define(
                          Our main goal is to provide the smoothest Web Analytics experience
                          possible.
                          <br />
-                         Therefore we do not enforce payments but ask for an
-                         affordable service fee.
+                         Therefore we do not enforce payments but ask for you to consider
+                         paying what you want.
                        </div>
                      </div>
                      <a


### PR DESCRIPTION
To me, the wording "[we] ask for an affordable service fee", sounds like a polite, US-American way of saying, "we will bill you and you will have to pay an 'affordable service fee'". This confused me together with the preceding half of the sentence "we do not enforce payments". My interpretation was "We will bill you for an 'affordable service fee' (whatever that means), but we won't enforce payments, meaning we won't sue you for the money, but technically you owe us."

I almost did not sign up for this amazing service, because of my confusion or uncertainty. Then I found the "Pay what you want" blog post. But since that is also two and half years old, I still wasn't 100% convinced that the service was still truly "pay what you want".