### PR TITLE
Fix Hour Display Offset in Dashboard

### DIFF
--- a/static/components/dashboard/hour.js
+++ b/static/components/dashboard/hour.js
@@ -14,7 +14,7 @@ customElements.define(
                     .map(
                         (entry) => `
                 <div class="hour-item">
-                  ${("0" + (parseInt(entry[0]) + 1)).slice(-2)}:00
+                  ${("0" + parseInt(entry[0])).slice(-2)}:00
                   <dashboard-number class="caption-strong">${entry[1]}</dashboard-number>
                 </div>`,
                     )


### PR DESCRIPTION
## Summary
Fixes a bug where visitor counts are displayed 1 hour ahead of their actual visit time in the dashboard.

## Problem
- **Issue**: Visitors arriving at 16:50 are displayed at 17:00 instead of 16:00
- **Cause**: Incorrect `+ 1` offset in hour display logic
- **Impact**: All users see misleading hourly statistics

## Solution
**File**: `/static/components/dashboard/hour.js`  
**Line**: 17  
**Change**: Remove `+ 1` from `parseInt(entry[0]) + 1`

```diff
- ${("0" + (parseInt(entry[0]) + 1)).slice(-2)}:00
+ ${("0" + parseInt(entry[0])).slice(-2)}:00
```

## Testing
- **Scenario Test**: 16:50 visit now correctly shows at 16:00  
- **Live Test**: Current time verification  
- **Full Coverage**: All 24-hour slots tested  

## Risk Assessment
- **Risk Level**: Very Low
- **Scope**: Frontend display only
- **Backward Compatibility**: No breaking changes
- **Data Safety**: Backend storage unchanged

---

**Before**: 16:50 visit → displayed at 17:00 (incorrect)  
**After**: 16:50 visit → displayed at 16:00 (correct)
